### PR TITLE
fix(API): Include waiting executions in public

### DIFF
--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -381,7 +381,7 @@ export class ExecutionService {
 	 * control, "current" means executions enqueued to start and running.
 	 */
 	async findLatestCurrentAndCompleted(query: ExecutionSummaries.RangeQuery) {
-		const currentStatuses: ExecutionStatus[] = ['new', 'running'];
+		const currentStatuses: ExecutionStatus[] = ['new', 'running', 'waiting'];
 
 		const completedStatuses = ExecutionStatusList.filter((s) => !currentStatuses.includes(s));
 

--- a/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
@@ -111,8 +111,10 @@ export = {
 			}
 
 			// get running workflows so we exclude them from the result
+			// but keep waiting executions as they should be visible in the API
 			const runningExecutionsIds = Container.get(ActiveExecutions)
 				.getActiveExecutions()
+				.filter(({ status }) => status !== 'waiting')
 				.map(({ id }) => id);
 
 			const filters = {


### PR DESCRIPTION
  API results

  The public API was incorrectly excluding waiting executions from
   results
  by treating them as 'running' executions. This fix ensures
  waiting
  executions appear in /api/v1/executions responses while still
  excluding
  truly running executions.

  - Filter out only non-waiting active executions in public API handler
  - Include 'waiting' status in currentStatuses for consistency
  - Add integration test for waiting executions handling

  Fixes #14237

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
